### PR TITLE
Add amd64 to find dll_path in check_dll_arch

### DIFF
--- a/installcab.py
+++ b/installcab.py
@@ -82,7 +82,7 @@ def get_winebin(arch):
 
 def check_dll_arch(dll_path):
     out = subprocess.check_output(['file', dll_path])
-    if b'x86-64' in out:
+    if (b'x86-64' in out) or (b'amd64' in out):
         return 'win64'
     else:
         return 'win32'


### PR DESCRIPTION
In some distributive (i.e. ALT Linux 9 Workstation K) path does not contains x86-64 string in path, but contains amd64. Without this both version libraries (32-bit and 64-bit) installed in syswow64 folder, instead 64-bit dll in system32 folder and 32-bit dll in syswow64 folder.