### PR TITLE
Better support for Proton

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,23 @@ Installcab based Media Foundation workaround for Wine
 - Resident Evil 7
 - Darksiders Warmastered Edition
 - Devil May Cry 5
+- Borderlands 3
 
 Just set WINEPREFIX and run install-mf-64.sh like this
 
-`WINEPREFIX="/home/gaben/.local/share/Steam/steamapps/compatdata/883710/pfx" ./install-mf-64.sh`
+`WINEPREFIX="/dev/brain/wine prefixes can be anywhere/folder" ./install-mf-64.sh`
+
+Steam stores Proton Wine prefixes as <STEAM FOLDER>/steamapps/compatdata/<GAME ID>/pfx
+
+Optionally you can use Proton's Wine instead of your system's Wine. This requires to provide the `-proton` argument and set PROTON like
+
+`PROTON=$HOME/.local/share/Steam/steamapps/common/Proton\ 5.0/ WINEPREFIX="$HOME/.local/share/Steam/steamapps/compatdata/397540/pfx" ./install-mf-64.sh -proton`
 
 Then copy the included mfplat.dll to the same directory as the `.exe` (e.g. re2.exe)
 
-installcab.py is exactly the same as upstream (https://github.com/tonix64/python-installcab/blob/master/installcab.py)
+installcab.py is exactly the same as upstream (https://github.com/tonix64/python-installcab/blob/master/installcab.py) (minor some small differences)
 
 ### Dependencies
 - python
 - cabextract
-- wine
+- wine (optional if proton used)

--- a/install-mf-32.sh
+++ b/install-mf-32.sh
@@ -1,6 +1,24 @@
 #!/bin/sh
 
-[ -z "$WINEPREFIX" ] && echo "WINEPREFIX not set" && exit 1
+check_env() {
+    [ -z "$1" ] && echo "$2 is not set" && exit 1
+}
+
+check_sanity() {
+    [ ! -d "$1/$2" ] && echo "$1 isn't a valid path" && exit 1
+}
+
+check_env "$WINEPREFIX" WINEPREFIX
+check_sanity "$WINEPREFIX" drive_c
+
+# User instructions:
+# Set PROTON to a Proton folder just like WINEPREFIX, pass -proton to script
+if [ "$1" = "-proton" ]; then
+    check_env "$PROTON" PROTON
+    check_sanity "$PROTON" dist/bin
+
+    export PATH="$PROTON/dist/bin:$PATH"
+fi
 
 set -e
 

--- a/install-mf-64.sh
+++ b/install-mf-64.sh
@@ -1,6 +1,24 @@
 #!/bin/sh
 
-[ -z "$WINEPREFIX" ] && echo "WINEPREFIX not set" && exit 1
+check_env() {
+    [ -z "$1" ] && echo "$2 is not set" && exit 1
+}
+
+check_sanity() {
+    [ ! -d "$1/$2" ] && echo "$1 isn't a valid path" && exit 1
+}
+
+check_env "$WINEPREFIX" WINEPREFIX
+check_sanity "$WINEPREFIX" drive_c
+
+# User instructions:
+# Set PROTON to a Proton folder just like WINEPREFIX, pass -proton to script
+if [ "$1" = "-proton" ]; then
+    check_env "$PROTON" PROTON
+    check_sanity "$PROTON" dist/bin
+
+    export PATH="$PROTON/dist/bin:$PATH"
+fi
 
 set -e
 

--- a/installcab.py
+++ b/installcab.py
@@ -22,7 +22,7 @@ def cleanup():
         shutil.rmtree(tmpdir)
 
 def bad_exit(text):
-    print(text)
+    print("ERROR: %s" % text)
     cleanup()
     sys.exit(1)
 
@@ -45,6 +45,16 @@ dest_map = {
     "win64:wow64": "System32",
     "win32:win32": "System32"
 }
+
+def check_bin_exists(pgm):
+    """Return true if it the pgm is available 
+    inside PATH env variable"""
+    path=os.getenv('PATH')
+    for p in path.split(os.path.pathsep):
+        p=os.path.join(p,pgm)
+        if os.path.exists(p) and os.access(p,os.X_OK):
+            return True
+    return False
 
 def check_wineprefix_arch(prefix_path):
     if not os.path.exists(prefix_path):
@@ -78,6 +88,11 @@ def get_winebin(arch):
         winebin = 'wine'
     else:
         winebin = 'wine64'
+    
+    if (not check_bin_exists(winebin)):
+        bad_exit("%s is not present in the path.\n" \
+            "Please consider to use '-proton' option or install wine on your system.\n" \
+            "See documentation for more details." % winebin)
     return winebin
 
 def check_dll_arch(dll_path):


### PR DESCRIPTION
Hi @z0z0z,

This is a pull request that Add:
- Better handling error when 'wine' or 'wine64' is not found (installcab.py). 
- `-proton` flag, similarly to mf-install. 

Moreover, I have updated the README to reflect these changes. 
With these changes, it would address the issues #17 and #3 

Best