### PR TITLE
Updated for newer protons with soldier runtime

### DIFF
--- a/installcab.py
+++ b/installcab.py
@@ -228,6 +228,8 @@ def install_dll(dll_path):
     dest_dir = get_dll_destdir(dll_path)
     file_name = os.path.basename(dll_path)
     print("- %s -> %s" % (file_name, dest_dir))
+    if os.path.islink(dest_dir + '/' + file_name):
+        os.unlink(dest_dir + '/' + file_name)
     shutil.copy(dll_path, dest_dir)
     register_dll(os.path.join(dest_dir, file_name))
 


### PR DESCRIPTION
That makes this script work with newer soldier-based protons. It removes the symbolic link and can copy the file without permission errors. It increases the prefix a little (because it skips deduplication) but at least doesn't modify the original proton installation, and when the game is uninstalled the entire prefix is removed with no harm.